### PR TITLE
CMParts: gestures: Specify a qualified user for update broadcast

### DIFF
--- a/src/org/cyanogenmod/cmparts/gestures/TouchscreenGestureSettings.java
+++ b/src/org/cyanogenmod/cmparts/gestures/TouchscreenGestureSettings.java
@@ -21,6 +21,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.os.UserHandle;
 import android.support.v7.preference.ListPreference;
 import android.support.v7.preference.PreferenceManager;
 
@@ -192,6 +193,6 @@ public class TouchscreenGestureSettings extends SettingsPreferenceFragment {
         intent.putExtra(TouchscreenGestureConstants.UPDATE_EXTRA_KEYCODE_MAPPING, keycodes);
         intent.putExtra(TouchscreenGestureConstants.UPDATE_EXTRA_ACTION_MAPPING, actions);
         intent.setFlags(Intent.FLAG_RECEIVER_REGISTERED_ONLY);
-        context.sendBroadcast(intent);
+        context.sendBroadcastAsUser(intent, UserHandle.CURRENT);
     }
 }


### PR DESCRIPTION
Fix:
02-02 14:26:06.600  2783  2783 W ContextImpl: Calling a method in the system process
without a qualified user: android.app.ContextImpl.sendBroadcast:877
android.content.ContextWrapper.sendBroadcast:421 android.content.ContextWrapper.sendBroadcast:421
org.cyanogenmod.cmparts.gestures.TouchscreenGestureSettings.sendUpdateBroadcast:200
org.cyanogenmod.cmparts.gestures.TouchscreenGestureSettings.restoreTouchscreenGestureStates:151

Change-Id: I0e980463f38d11114d48222e4ef3dea60f8e0185